### PR TITLE
clean-up

### DIFF
--- a/doc/DOCKER_setup.md
+++ b/doc/DOCKER_setup.md
@@ -163,6 +163,8 @@ Available commands:
 
   bitcoin-cli                   Launch a bitcoin-cli console for interacting with bitcoind RPC API.
 
+  clean                         Free disk space by deleting docker dangling images and images of previous versions.
+
   install                       Install your Dojo.
 
   logs [module] [options]       Display the logs of your Dojo. Use CTRL+C to stop the logs.

--- a/docker/my-dojo/install/upgrade-scripts.sh
+++ b/docker/my-dojo/install/upgrade-scripts.sh
@@ -61,5 +61,7 @@ cleanup() {
   #################
 
   # Remove deprecated bitcoin.conf file
-  rm ./bitcoin/bitcoin.conf
+  if [ -f ./bitcoin/bitcoin.conf ]; then
+    rm ./bitcoin/bitcoin.conf
+  fi
 }


### PR DESCRIPTION
add a clean command to dojo.sh for the deletion of docker dangling images and old dojo images.

fix for missing check in cleanup function of upgrade-scripts.sh