### PR TITLE
update nodejs packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,9 +22,9 @@
       }
     },
     "ajv": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
-      "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+      "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
       "requires": {
         "fast-deep-equal": "2.0.1",
         "fast-json-stable-stringify": "2.0.0",
@@ -112,11 +112,11 @@
       "dev": true
     },
     "base-x": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.5.tgz",
-      "integrity": "sha512-C3picSgzPSLE+jW3tcBzJoGwitOtazb5B+5YmAxZm2ybmTi9LNgAtDO/jjVEBZwHoXmDBZ9m/IELj3elJVRBcA==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.6.tgz",
+      "integrity": "sha512-4PaF8u2+AlViJxRVjurkLTxpp7CaFRD/jo5rPT9ONnKxyhQ8f59yzamEvq7EkriG56yn5On4ONyaG75HLqr46w==",
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "5.2.0"
       }
     },
     "bcrypt-pbkdf": {
@@ -158,8 +158,8 @@
         "create-hash": "1.2.0",
         "pbkdf2": "3.0.17",
         "randombytes": "2.1.0",
-        "safe-buffer": "5.1.2",
-        "unorm": "1.5.0"
+        "safe-buffer": "5.2.0",
+        "unorm": "1.6.0"
       }
     },
     "bip66": {
@@ -167,7 +167,7 @@
       "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
       "integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "5.2.0"
       }
     },
     "bitcoin-ops": {
@@ -201,7 +201,7 @@
         "merkle-lib": "2.0.10",
         "pushdata-bitcoin": "1.0.1",
         "randombytes": "2.1.0",
-        "safe-buffer": "5.1.2",
+        "safe-buffer": "5.2.0",
         "typeforce": "1.18.0",
         "varuint-bitcoin": "1.1.0",
         "wif": "2.0.6"
@@ -249,7 +249,7 @@
       "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
       "requires": {
         "readable-stream": "2.3.6",
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "5.2.0"
       }
     },
     "bn.js": {
@@ -304,8 +304,8 @@
         "cipher-base": "1.0.4",
         "create-hash": "1.2.0",
         "evp_bytestokey": "1.0.3",
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.2"
+        "inherits": "2.0.4",
+        "safe-buffer": "5.2.0"
       }
     },
     "bs58": {
@@ -313,7 +313,7 @@
       "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
       "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
       "requires": {
-        "base-x": "3.0.5"
+        "base-x": "3.0.6"
       }
     },
     "bs58check": {
@@ -323,7 +323,7 @@
       "requires": {
         "bs58": "4.0.1",
         "create-hash": "1.2.0",
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "5.2.0"
       }
     },
     "buffer-alloc": {
@@ -376,17 +376,17 @@
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "chownr": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
-      "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.2.tgz",
+      "integrity": "sha512-GkfeAQh+QNy3wquu9oIZr6SS5x7wGdSgNQvD10X3r+AZr1Oys22HW8kAmDMvNg2+Dm0TeGaEuO8gFwdBXxwO8A=="
     },
     "cipher-base": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
       "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
       "requires": {
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.2"
+        "inherits": "2.0.4",
+        "safe-buffer": "5.2.0"
       }
     },
     "code-point-at": {
@@ -463,7 +463,7 @@
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "requires": {
         "cipher-base": "1.0.4",
-        "inherits": "2.0.3",
+        "inherits": "2.0.4",
         "md5.js": "1.3.5",
         "ripemd160": "2.0.2",
         "sha.js": "2.4.11"
@@ -476,9 +476,9 @@
       "requires": {
         "cipher-base": "1.0.4",
         "create-hash": "1.2.0",
-        "inherits": "2.0.3",
+        "inherits": "2.0.4",
         "ripemd160": "2.0.2",
-        "safe-buffer": "5.1.2",
+        "safe-buffer": "5.2.0",
         "sha.js": "2.4.11"
       }
     },
@@ -586,7 +586,7 @@
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
       "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "5.2.0"
       }
     },
     "ecurve": {
@@ -595,7 +595,7 @@
       "integrity": "sha512-/BzEjNfiSuB7jIWKcS/z8FK9jNjmEWvUV2YZ4RLSmcDtP7Lq0m6FvDuSnJpBlDpGRpfRQeTLGLBI8H+kEv0r+w==",
       "requires": {
         "bigi": "1.4.2",
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "5.2.0"
       }
     },
     "ee-first": {
@@ -604,15 +604,15 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "elliptic": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.1.tgz",
-      "integrity": "sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.0.tgz",
+      "integrity": "sha512-eFOJTMyCYb7xtE/caJ6JJu+bhi67WCYNbkGSknu20pmM8Ke/bqOfdnZWxyoGN26JgfxTbXrsCkEw4KheCT/KGg==",
       "requires": {
         "bn.js": "4.11.8",
         "brorand": "1.1.0",
         "hash.js": "1.1.7",
         "hmac-drbg": "1.0.1",
-        "inherits": "2.0.3",
+        "inherits": "2.0.4",
         "minimalistic-assert": "1.0.1",
         "minimalistic-crypto-utils": "1.0.1"
       }
@@ -635,7 +635,7 @@
       "resolved": "https://registry.npmjs.org/error-system/-/error-system-1.0.1.tgz",
       "integrity": "sha1-BxU79HecB5Dnpg7QXvn0fRMYagI=",
       "requires": {
-        "inherits": "2.0.3"
+        "inherits": "2.0.4"
       }
     },
     "es6-promise": {
@@ -673,7 +673,7 @@
       "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
       "requires": {
         "md5.js": "1.3.5",
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "5.2.0"
       }
     },
     "expand-template": {
@@ -744,6 +744,11 @@
           "version": "0.4.19",
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
           "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
         "qs": {
           "version": "6.5.1",
@@ -940,7 +945,7 @@
       "requires": {
         "fs.realpath": "1.0.0",
         "inflight": "1.0.6",
-        "inherits": "2.0.3",
+        "inherits": "2.0.4",
         "minimatch": "3.0.4",
         "once": "1.4.0",
         "path-is-absolute": "1.0.1"
@@ -968,7 +973,7 @@
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
       "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
       "requires": {
-        "ajv": "6.10.0",
+        "ajv": "6.10.2",
         "har-schema": "2.0.0"
       }
     },
@@ -988,8 +993,8 @@
       "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
       "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
       "requires": {
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.2"
+        "inherits": "2.0.4",
+        "safe-buffer": "5.2.0"
       }
     },
     "hash.js": {
@@ -997,7 +1002,7 @@
       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
       "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
       "requires": {
-        "inherits": "2.0.3",
+        "inherits": "2.0.4",
         "minimalistic-assert": "1.0.1"
       }
     },
@@ -1077,6 +1082,13 @@
         "inherits": "2.0.3",
         "setprototypeof": "1.1.0",
         "statuses": "1.5.0"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+        }
       }
     },
     "http-signature": {
@@ -1113,9 +1125,9 @@
       }
     },
     "inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ini": {
       "version": "1.3.5",
@@ -1223,7 +1235,7 @@
       "requires": {
         "buffer-equal-constant-time": "1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "5.2.0"
       }
     },
     "jws": {
@@ -1232,13 +1244,13 @@
       "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
       "requires": {
         "jwa": "1.4.1",
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "5.2.0"
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.14",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
+      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw=="
     },
     "lodash._baseassign": {
       "version": "3.2.0",
@@ -1376,8 +1388,8 @@
       "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
       "requires": {
         "hash-base": "3.0.4",
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.2"
+        "inherits": "2.0.4",
+        "safe-buffer": "5.2.0"
       }
     },
     "media-typer": {
@@ -1507,6 +1519,13 @@
         "readable-stream": "2.3.6",
         "safe-buffer": "5.1.2",
         "sqlstring": "2.3.1"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        }
       }
     },
     "nan": {
@@ -1525,9 +1544,9 @@
       "integrity": "sha1-ICtIAhoMTL3i34DeFaF0Q8i0OYA="
     },
     "node-abi": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.8.0.tgz",
-      "integrity": "sha512-1/aa2clS0pue0HjckL62CsbhWWU35HARvBDXcJtYKbYR7LnIutmpxmXbuDMV9kEviD2lP/wACOgWmmwljghHyQ==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.9.0.tgz",
+      "integrity": "sha512-jmEOvv0eanWjhX8dX1pmjb7oJl1U1oR4FOh0b2GnvALwSYoOdU7sj+kLDSAyjo4pfC9aj/IxkloxdLJQhSSQBA==",
       "requires": {
         "semver": "5.7.0"
       }
@@ -1636,7 +1655,7 @@
         "create-hash": "1.2.0",
         "create-hmac": "1.1.7",
         "ripemd160": "2.0.2",
-        "safe-buffer": "5.1.2",
+        "safe-buffer": "5.2.0",
         "sha.js": "2.4.11"
       }
     },
@@ -1665,7 +1684,7 @@
         "github-from-package": "0.0.0",
         "minimist": "1.2.0",
         "mkdirp": "0.5.1",
-        "node-abi": "2.8.0",
+        "node-abi": "2.9.0",
         "noop-logger": "0.1.1",
         "npmlog": "4.1.2",
         "os-homedir": "1.0.2",
@@ -1678,9 +1697,9 @@
       }
     },
     "process-nextick-args": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "promise-useful-utils": {
       "version": "0.2.1",
@@ -1706,9 +1725,9 @@
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
     "psl": {
-      "version": "1.1.32",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.32.tgz",
-      "integrity": "sha512-MHACAkHpihU/REGGPLj4sEfc/XKW2bheigvHO1dUqjaKigMp1C8+WLQYRGgeKFMsw5PMfegZcaN8IDXK/cD0+g=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.2.0.tgz",
+      "integrity": "sha512-GEn74ZffufCmkDDLNcl3uuyF/aSD6exEyh1v/ZSdAomB82t6G9hzJVRx0jBmLDW+VfZqks3aScmMw9DszwUalA=="
     },
     "pump": {
       "version": "2.0.1",
@@ -1742,7 +1761,7 @@
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
       "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "5.2.0"
       }
     },
     "range-parser": {
@@ -1778,12 +1797,19 @@
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
         "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
+        "inherits": "2.0.4",
         "isarray": "1.0.0",
-        "process-nextick-args": "2.0.0",
+        "process-nextick-args": "2.0.1",
         "safe-buffer": "5.1.2",
         "string_decoder": "1.1.1",
         "util-deprecate": "1.0.2"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        }
       }
     },
     "referrer-policy": {
@@ -1812,7 +1838,7 @@
         "oauth-sign": "0.9.0",
         "performance-now": "2.1.0",
         "qs": "6.5.2",
-        "safe-buffer": "5.1.2",
+        "safe-buffer": "5.2.0",
         "tough-cookie": "2.4.3",
         "tunnel-agent": "0.6.0",
         "uuid": "3.3.2"
@@ -1823,7 +1849,7 @@
       "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
       "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
       "requires": {
-        "lodash": "4.17.11"
+        "lodash": "4.17.14"
       }
     },
     "request-promise-native": {
@@ -1842,13 +1868,13 @@
       "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
       "requires": {
         "hash-base": "3.0.4",
-        "inherits": "2.0.3"
+        "inherits": "2.0.4"
       }
     },
     "safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+      "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -1865,9 +1891,9 @@
         "bn.js": "4.11.8",
         "create-hash": "1.2.0",
         "drbg.js": "1.0.1",
-        "elliptic": "6.4.1",
+        "elliptic": "6.5.0",
         "nan": "2.14.0",
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "5.2.0"
       }
     },
     "semver": {
@@ -1928,8 +1954,8 @@
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "requires": {
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.2"
+        "inherits": "2.0.4",
+        "safe-buffer": "5.2.0"
       }
     },
     "signal-exit": {
@@ -2022,6 +2048,13 @@
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "requires": {
         "safe-buffer": "5.1.2"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        }
       }
     },
     "strip-ansi": {
@@ -2051,7 +2084,7 @@
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.3.tgz",
       "integrity": "sha512-NvCeXpYx7OsmOh8zIOP/ebG55zZmxLE0etfWRbWok+q2Qo8x/vOR/IJT1taADXPe+jsiu9axDb3X4B+iIgNlKw==",
       "requires": {
-        "chownr": "1.1.1",
+        "chownr": "1.1.2",
         "mkdirp": "0.5.1",
         "pump": "1.0.3",
         "tar-stream": "1.6.2"
@@ -2079,7 +2112,7 @@
         "fs-constants": "1.0.0",
         "readable-stream": "2.3.6",
         "to-buffer": "1.1.1",
-        "xtend": "4.0.1"
+        "xtend": "4.0.2"
       }
     },
     "to-buffer": {
@@ -2092,7 +2125,7 @@
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
       "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
       "requires": {
-        "psl": "1.1.32",
+        "psl": "1.2.0",
         "punycode": "1.4.1"
       },
       "dependencies": {
@@ -2108,7 +2141,7 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "5.2.0"
       }
     },
     "tweetnacl": {
@@ -2139,9 +2172,9 @@
       "integrity": "sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g=="
     },
     "unorm": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/unorm/-/unorm-1.5.0.tgz",
-      "integrity": "sha512-sMfSWoiRaXXeDZSXC+YRZ23H4xchQpwxjpw1tmfR+kgbBCaOgln4NI0LXejJIhnBuKINrB3WRn+ZI8IWssirVw=="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/unorm/-/unorm-1.6.0.tgz",
+      "integrity": "sha512-b2/KCUlYZUeA7JFUuRJZPUtr4gZvBh7tavtv4fvk4+KV9pfGiR6CQAQAWl49ZpR3ts2dk4FYkP7EIgDJoiOLDA=="
     },
     "unpipe": {
       "version": "1.0.0",
@@ -2181,7 +2214,7 @@
       "resolved": "https://registry.npmjs.org/varuint-bitcoin/-/varuint-bitcoin-1.1.0.tgz",
       "integrity": "sha512-jCEPG+COU/1Rp84neKTyDJQr478/hAfVp5xxYn09QEH0yBjbmPeMfuuQIrp+BUD83hybtYZKhr5elV3bvdV1bA==",
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "5.2.0"
       }
     },
     "vary": {
@@ -2242,9 +2275,9 @@
       "integrity": "sha512-rx3GzJlgEeZ08MIcDsU2vY2B1QEriUKJTSiNHHUIem6eg9pzVOr2TL3Y4Pd6TMAM5D5azGjcxqI62piITBDHVg=="
     },
     "xtend": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
     "yaeti": {
       "version": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "generic-pool": "3.4.2",
     "heapdump": "0.3.9",
     "helmet": "3.12.1",
+    "lodash": "4.17.14",
     "lru-cache": "4.0.2",
     "mysql": "2.16.0",
     "passport": "0.4.0",


### PR DESCRIPTION
force update of lodash to v4.17.14 for [CVE-2019-10744](https://github.com/lodash/lodash/pull/4336)