### PR TITLE
keyserver.ubuntu

### DIFF
--- a/docker/my-dojo/bitcoin/Dockerfile
+++ b/docker/my-dojo/bitcoin/Dockerfile
@@ -21,7 +21,7 @@ RUN     set -ex && \
         cd /tmp && \
         wget -qO bitcoin.tar.gz "$BITCOIN_URL" && \
         echo "$BITCOIN_SHA256 bitcoin.tar.gz" | sha256sum -c - && \
-        gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$BITCOIN_PGP_KEY" && \
+        gpg --batch --keyserver htp://keyserver.ubuntu.com:80 --recv-keys "$BITCOIN_PGP_KEY" && \
         wget -qO bitcoin.asc "$BITCOIN_ASC_URL" && \
         gpg --batch --verify bitcoin.asc && \
         tar -xzvf bitcoin.tar.gz -C /usr/local --strip-components=1 --exclude=*-qt && \


### PR DESCRIPTION
I am running windows 10.  Docker 2.1.0.1 with linux containers on a different drive (E). Running dojo from dev branch db89208. I was unable to install before this change.