### PR TITLE
retry to send sql requests on detection of a lock

### DIFF
--- a/lib/db/mysql-db-wrapper.js
+++ b/lib/db/mysql-db-wrapper.js
@@ -378,15 +378,33 @@ class MySqlDbWrapper {
   /**
    * Send a query
    */
-  async _query(query) {
+  async _query(query, retries) {
     queryDebug && Logger.info(query)
+
+    if (retries == null)
+      retries = 5
 
     return new Promise((resolve, reject) => {
       try {
-        this.pool.query(query, null, (err, result, fields) => {
+        this.pool.query(query, null, async (err, result, fields) => {
           if (err) {
-            this.queryError(err, query)
-            reject(err)
+            // Retry the request on lock errors
+            if ((err.code == 'ER_LOCK_DEADLOCK' || 
+              err.code == 'ER_LOCK_TIMEOUT' || 
+              err.code == 'ER_LOCK_WAIT_TIMEOUT') && (retries > 0)
+            ) {
+              try {
+                this.queryError('Lock detected. Retry request in a few ms', query)
+                const sleepMillis = Math.floor((Math.random() * 100) + 1)
+                await new Promise(resolve2 => setTimeout(resolve2, sleepMillis))
+                const res = await this._query(query, retries - 1)
+                resolve(res)
+              } catch(err) {
+                reject(err)
+              }
+            } else {
+              reject(err)
+            }
           } else {
             queryDebug && Logger.info(result)
             resolve(result)


### PR DESCRIPTION
fix a potential issue with db locks leading to transactions missed by the tracker.