### PR TITLE
improve the tracking of loose addresses

### DIFF
--- a/lib/wallet/address-info.js
+++ b/lib/wallet/address-info.js
@@ -65,9 +65,12 @@ class AddressInfo {
       this.path = ['M', info.hdAddrChain, info.hdAddrIndex].join('/')
     }
 
-    if (res.loose.indexOf(this.address) > -1) {
-      this.tracked = true
-      this.type = 'loose'
+    for (let a of res.loose) {
+      if (a.addrAddress == this.address) {
+        this.tracked = true
+        this.type = 'loose'
+        break
+      }
     }
 
     return this.loadInfo()

--- a/lib/wallet/wallet-service.js
+++ b/lib/wallet/wallet-service.js
@@ -9,6 +9,9 @@ const Logger = require('../logger')
 const db = require('../db/mysql-db-wrapper')
 const hdaService = require('../bitcoin/hd-accounts-service')
 const hdaHelper = require('../bitcoin/hd-accounts-helper')
+const network = require('../bitcoin/network')
+const activeNet = network.network
+const keys = require('../../keys')[network.key]
 const WalletInfo = require('./wallet-info')
 
 
@@ -60,9 +63,13 @@ class WalletService {
       await db.addAddresses(bip49.addrs)
       await db.addAddresses(bip84.addrs)
       await db.addAddresses(pubkeys.addrs)
-      // Ensure addresses exist and filter them
+      // Ensure addresses exist
       await walletInfo.ensureAddresses()
-      //await this._forceEnsureAddressesForActivePubkeys(active)
+      // Force import of addresses associated to paynyms
+      // if dojo relies on a local index
+      if (keys.indexer.active != 'third_party_explorer')
+        await this._forceEnsureAddressesForActivePubkeys(active)
+      // Filter the address and load them
       await walletInfo.filterAddresses()
       await walletInfo.loadAddressesInfo()
       // Load the most recent transactions
@@ -136,9 +143,13 @@ class WalletService {
       await db.addAddresses(bip49.addrs)
       await db.addAddresses(bip84.addrs)
       await db.addAddresses(pubkeys.addrs)
-      // Ensure addresses exist and filter them
+      // Ensure addresses exist
       await walletInfo.ensureAddresses()
-      //await this._forceEnsureAddressesForActivePubkeys(active)
+      // Force import of addresses associated to paynyms
+      // if dojo relies on a local index
+      if (keys.indexer.active != 'third_party_explorer')
+        await this._forceEnsureAddressesForActivePubkeys(active)
+      // Filter the addresses
       await walletInfo.filterAddresses()
       // Load the utxos
       await walletInfo.loadUtxos()


### PR DESCRIPTION
- fix detection of loose addresses for the maintenance tool

- force the immediate tracking of paynyms addresses when dojo is relying on a local data source