### PR TITLE
Add CircleCI Automated Docker image builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,492 @@
+version: 2
+jobs:
+  build:
+    machine: 
+      docker_layer_caching: false
+    steps: 
+      - checkout
+  # publish jobs require $DOCKERHUB_REPO, $DOCKERHUB_USER, $DOCKERHUB_PASS defined
+  publish_docker_linuxamd64_dojo-nodejs:
+    machine:
+      docker_layer_caching: false
+    steps:
+      - checkout  
+      - run:
+          command: |
+            LATEST_TAG=${CIRCLE_TAG:1} #trim v from tag
+            #
+            LATEST_TAG=${CIRCLE_TAG:1} #trim v from tag
+            if [ -z "$LATEST_TAG" ]
+            then
+              LATEST_TAG="latest" && [[ "$CIRCLE_BRANCH" == "develop" ]] && LATEST_TAG="dev"
+            fi
+            #
+            sudo docker build --pull -t $DOCKERHUB_REPO/dojo-nodejs:$LATEST_TAG-amd64 -f docker/my-dojo/node/Dockerfile .
+            sudo docker login --username=$DOCKERHUB_USER --password=$DOCKERHUB_PASS
+            sudo docker push $DOCKERHUB_REPO/dojo-nodejs:$LATEST_TAG-amd64
+  publish_docker_linuxarm32_dojo-nodejs:
+    machine:
+      docker_layer_caching: false
+    steps:
+      - checkout  
+      - run:
+          command: |
+            sudo docker run --rm --privileged multiarch/qemu-user-static:register --reset
+            LATEST_TAG=${CIRCLE_TAG:1} #trim v from tag
+            #
+            LATEST_TAG=${CIRCLE_TAG:1} #trim v from tag
+            if [ -z "$LATEST_TAG" ]
+            then
+              LATEST_TAG="latest" && [[ "$CIRCLE_BRANCH" == "develop" ]] && LATEST_TAG="dev"
+            fi
+            #
+            sudo docker build --pull -t $DOCKERHUB_REPO/dojo-nodejs:$LATEST_TAG-arm32v7 -f docker/my-dojo/node/Dockerfile .
+            sudo docker login --username=$DOCKERHUB_USER --password=$DOCKERHUB_PASS
+            sudo docker push $DOCKERHUB_REPO/dojo-nodejs:$LATEST_TAG-arm32v7
+  publish_docker_linuxarm64_dojo-nodejs:
+    machine:
+      docker_layer_caching: false
+    steps:
+      - checkout
+      - run:
+          command: |
+            sudo docker run --rm --privileged multiarch/qemu-user-static:register --reset
+            LATEST_TAG=${CIRCLE_TAG:1} #trim v from tag
+            #
+            LATEST_TAG=${CIRCLE_TAG:1} #trim v from tag
+            if [ -z "$LATEST_TAG" ]
+            then
+              LATEST_TAG="latest" && [[ "$CIRCLE_BRANCH" == "develop" ]] && LATEST_TAG="dev"
+            fi
+            #
+            sudo docker build --pull -t $DOCKERHUB_REPO/dojo-nodejs:$LATEST_TAG-arm64v8 -f docker/my-dojo/node/Dockerfile .
+            sudo docker login --username=$DOCKERHUB_USER --password=$DOCKERHUB_PASS
+            sudo docker push $DOCKERHUB_REPO/dojo-nodejs:$LATEST_TAG-arm64v8
+  publish_docker_multiarch_dojo-nodejs:
+    machine:
+      enabled: true
+      image: circleci/classic:201808-01
+    steps:
+      - run:
+          command: |
+            # Turn on Experimental features
+            sudo mkdir $HOME/.docker
+            sudo sh -c 'echo "{ \"experimental\": \"enabled\" }" >> $HOME/.docker/config.json'
+            #
+            sudo docker login --username=$DOCKERHUB_USER --password=$DOCKERHUB_PASS
+            #
+            LATEST_TAG=${CIRCLE_TAG:1} #trim v from tag
+            #
+            LATEST_TAG=${CIRCLE_TAG:1} #trim v from tag
+            if [ -z "$LATEST_TAG" ]
+            then
+              LATEST_TAG="latest" && [[ "$CIRCLE_BRANCH" == "develop" ]] && LATEST_TAG="dev"
+            fi
+            #
+            sudo docker manifest create --amend $DOCKERHUB_REPO/dojo-nodejs:$LATEST_TAG $DOCKERHUB_REPO/dojo-nodejs:$LATEST_TAG-amd64 $DOCKERHUB_REPO/dojo-nodejs:$LATEST_TAG-arm32v7 $DOCKERHUB_REPO/dojo-nodejs:$LATEST_TAG-arm64v8
+            sudo docker manifest annotate $DOCKERHUB_REPO/dojo-nodejs:$LATEST_TAG $DOCKERHUB_REPO/dojo-nodejs:$LATEST_TAG-amd64 --os linux --arch amd64
+            sudo docker manifest annotate $DOCKERHUB_REPO/dojo-nodejs:$LATEST_TAG $DOCKERHUB_REPO/dojo-nodejs:$LATEST_TAG-arm32v7 --os linux --arch arm --variant v7
+            sudo docker manifest annotate $DOCKERHUB_REPO/dojo-nodejs:$LATEST_TAG $DOCKERHUB_REPO/dojo-nodejs:$LATEST_TAG-arm64v8 --os linux --arch arm64 --variant v8
+            sudo docker manifest push $DOCKERHUB_REPO/dojo-nodejs:$LATEST_TAG -p
+
+  publish_docker_linuxamd64_dojo-db:
+    machine:
+      docker_layer_caching: false
+    steps:
+      - checkout  
+      - run:
+          command: |
+            LATEST_TAG=${CIRCLE_TAG:1} #trim v from tag
+            #
+            LATEST_TAG=${CIRCLE_TAG:1} #trim v from tag
+            if [ -z "$LATEST_TAG" ]
+            then
+              LATEST_TAG="latest" && [[ "$CIRCLE_BRANCH" == "develop" ]] && LATEST_TAG="dev"
+            fi
+            #
+            sudo docker build --pull -t $DOCKERHUB_REPO/dojo-db:$LATEST_TAG-amd64 -f docker/my-dojo/node/Dockerfile .
+            sudo docker login --username=$DOCKERHUB_USER --password=$DOCKERHUB_PASS
+            sudo docker push $DOCKERHUB_REPO/dojo-db:$LATEST_TAG-amd64
+  publish_docker_linuxarm32_dojo-db:
+    machine:
+      docker_layer_caching: false
+    steps:
+      - checkout  
+      - run:
+          command: |
+            sudo docker run --rm --privileged multiarch/qemu-user-static:register --reset
+            LATEST_TAG=${CIRCLE_TAG:1} #trim v from tag
+            #
+            LATEST_TAG=${CIRCLE_TAG:1} #trim v from tag
+            if [ -z "$LATEST_TAG" ]
+            then
+              LATEST_TAG="latest" && [[ "$CIRCLE_BRANCH" == "develop" ]] && LATEST_TAG="dev"
+            fi
+            #
+            sudo docker build --pull -t $DOCKERHUB_REPO/dojo-db:$LATEST_TAG-arm32v7 -f docker/my-dojo/node/Dockerfile .
+            sudo docker login --username=$DOCKERHUB_USER --password=$DOCKERHUB_PASS
+            sudo docker push $DOCKERHUB_REPO/dojo-db:$LATEST_TAG-arm32v7
+  publish_docker_linuxarm64_dojo-db:
+    machine:
+      docker_layer_caching: false
+    steps:
+      - checkout
+      - run:
+          command: |
+            sudo docker run --rm --privileged multiarch/qemu-user-static:register --reset
+            LATEST_TAG=${CIRCLE_TAG:1} #trim v from tag
+            #
+            LATEST_TAG=${CIRCLE_TAG:1} #trim v from tag
+            if [ -z "$LATEST_TAG" ]
+            then
+              LATEST_TAG="latest" && [[ "$CIRCLE_BRANCH" == "develop" ]] && LATEST_TAG="dev"
+            fi
+            #
+            sudo docker build --pull -t $DOCKERHUB_REPO/dojo-db:$LATEST_TAG-arm64v8 -f docker/my-dojo/node/Dockerfile .
+            sudo docker login --username=$DOCKERHUB_USER --password=$DOCKERHUB_PASS
+            sudo docker push $DOCKERHUB_REPO/dojo-db:$LATEST_TAG-arm64v8
+  publish_docker_multiarch_dojo-db:
+    machine:
+      enabled: true
+      image: circleci/classic:201808-01
+    steps:
+      - run:
+          command: |
+            # Turn on Experimental features
+            sudo mkdir $HOME/.docker
+            sudo sh -c 'echo "{ \"experimental\": \"enabled\" }" >> $HOME/.docker/config.json'
+            #
+            sudo docker login --username=$DOCKERHUB_USER --password=$DOCKERHUB_PASS
+            #
+            LATEST_TAG=${CIRCLE_TAG:1} #trim v from tag
+            if [ -z "$LATEST_TAG" ]
+            then
+              LATEST_TAG="latest" && [[ "$CIRCLE_BRANCH" == "develop" ]] && LATEST_TAG="dev"
+            fi
+            #
+            sudo docker manifest create --amend $DOCKERHUB_REPO/dojo-db:$LATEST_TAG $DOCKERHUB_REPO/dojo-db:$LATEST_TAG-amd64 $DOCKERHUB_REPO/dojo-db:$LATEST_TAG-arm32v7 $DOCKERHUB_REPO/dojo-db:$LATEST_TAG-arm64v8
+            sudo docker manifest annotate $DOCKERHUB_REPO/dojo-db:$LATEST_TAG $DOCKERHUB_REPO/dojo-db:$LATEST_TAG-amd64 --os linux --arch amd64
+            sudo docker manifest annotate $DOCKERHUB_REPO/dojo-db:$LATEST_TAG $DOCKERHUB_REPO/dojo-db:$LATEST_TAG-arm32v7 --os linux --arch arm --variant v7
+            sudo docker manifest annotate $DOCKERHUB_REPO/dojo-db:$LATEST_TAG $DOCKERHUB_REPO/dojo-db:$LATEST_TAG-arm64v8 --os linux --arch arm64 --variant v8
+            sudo docker manifest push $DOCKERHUB_REPO/dojo-db:$LATEST_TAG -p
+  publish_docker_linuxamd64_dojo-nginx:
+    machine:
+      docker_layer_caching: false
+    steps:
+      - checkout  
+      - run:
+          command: |
+            LATEST_TAG=${CIRCLE_TAG:1} #trim v from tag
+            #
+            LATEST_TAG=${CIRCLE_TAG:1} #trim v from tag
+            if [ -z "$LATEST_TAG" ]
+            then
+              LATEST_TAG="latest" && [[ "$CIRCLE_BRANCH" == "develop" ]] && LATEST_TAG="dev"
+            fi
+            #
+            sudo docker build --pull -t $DOCKERHUB_REPO/dojo-nginx:$LATEST_TAG-amd64 -f  docker/my-dojo/nginx/Dockerfile docker/my-dojo/nginx
+            sudo docker login --username=$DOCKERHUB_USER --password=$DOCKERHUB_PASS
+            sudo docker push $DOCKERHUB_REPO/dojo-nginx:$LATEST_TAG-amd64
+  publish_docker_linuxarm32_dojo-nginx:
+    machine:
+      docker_layer_caching: false
+    steps:
+      - checkout  
+      - run:
+          command: |
+            sudo docker run --rm --privileged multiarch/qemu-user-static:register --reset
+            LATEST_TAG=${CIRCLE_TAG:1} #trim v from tag
+            #
+            LATEST_TAG=${CIRCLE_TAG:1} #trim v from tag
+            if [ -z "$LATEST_TAG" ]
+            then
+              LATEST_TAG="latest" && [[ "$CIRCLE_BRANCH" == "develop" ]] && LATEST_TAG="dev"
+            fi
+            #
+            sudo docker build --pull -t $DOCKERHUB_REPO/dojo-nginx:$LATEST_TAG-arm32v7 -f  docker/my-dojo/nginx/Dockerfile docker/my-dojo/nginx
+            sudo docker login --username=$DOCKERHUB_USER --password=$DOCKERHUB_PASS
+            sudo docker push $DOCKERHUB_REPO/dojo-nginx:$LATEST_TAG-arm32v7
+  publish_docker_linuxarm64_dojo-nginx:
+    machine:
+      docker_layer_caching: false
+    steps:
+      - checkout
+      - run:
+          command: |
+            sudo docker run --rm --privileged multiarch/qemu-user-static:register --reset
+            LATEST_TAG=${CIRCLE_TAG:1} #trim v from tag
+            #
+            LATEST_TAG=${CIRCLE_TAG:1} #trim v from tag
+            if [ -z "$LATEST_TAG" ]
+            then
+              LATEST_TAG="latest" && [[ "$CIRCLE_BRANCH" == "develop" ]] && LATEST_TAG="dev"
+            fi
+            #
+            sudo docker build --pull -t $DOCKERHUB_REPO/dojo-nginx:$LATEST_TAG-arm64v8 -f  docker/my-dojo/nginx/Dockerfile docker/my-dojo/nginx
+            sudo docker login --username=$DOCKERHUB_USER --password=$DOCKERHUB_PASS
+            sudo docker push $DOCKERHUB_REPO/dojo-nginx:$LATEST_TAG-arm64v8
+  publish_docker_multiarch_dojo-nginx:
+    machine:
+      enabled: true
+      image: circleci/classic:201808-01
+    steps:
+      - run:
+          command: |
+            # Turn on Experimental features
+            sudo mkdir $HOME/.docker
+            sudo sh -c 'echo "{ \"experimental\": \"enabled\" }" >> $HOME/.docker/config.json'
+            #
+            sudo docker login --username=$DOCKERHUB_USER --password=$DOCKERHUB_PASS
+            #
+            LATEST_TAG=${CIRCLE_TAG:1} #trim v from tag
+            #
+            LATEST_TAG=${CIRCLE_TAG:1} #trim v from tag
+            if [ -z "$LATEST_TAG" ]
+            then
+              LATEST_TAG="latest" && [[ "$CIRCLE_BRANCH" == "develop" ]] && LATEST_TAG="dev"
+            fi
+            #
+            sudo docker manifest create --amend $DOCKERHUB_REPO/dojo-nginx:$LATEST_TAG $DOCKERHUB_REPO/dojo-nginx:$LATEST_TAG-amd64 $DOCKERHUB_REPO/dojo-nginx:$LATEST_TAG-arm32v7 $DOCKERHUB_REPO/dojo-nginx:$LATEST_TAG-arm64v8
+            sudo docker manifest annotate $DOCKERHUB_REPO/dojo-nginx:$LATEST_TAG $DOCKERHUB_REPO/dojo-nginx:$LATEST_TAG-amd64 --os linux --arch amd64
+            sudo docker manifest annotate $DOCKERHUB_REPO/dojo-nginx:$LATEST_TAG $DOCKERHUB_REPO/dojo-nginx:$LATEST_TAG-arm32v7 --os linux --arch arm --variant v7
+            sudo docker manifest annotate $DOCKERHUB_REPO/dojo-nginx:$LATEST_TAG $DOCKERHUB_REPO/dojo-nginx:$LATEST_TAG-arm64v8 --os linux --arch arm64 --variant v8
+            sudo docker manifest push $DOCKERHUB_REPO/dojo-nginx:$LATEST_TAG -p
+
+  publish_docker_linuxamd64_dojo-tor:
+    machine:
+      docker_layer_caching: false
+    steps:
+      - checkout  
+      - run:
+          command: |
+            LATEST_TAG=${CIRCLE_TAG:1} #trim v from tag
+            #
+            LATEST_TAG=${CIRCLE_TAG:1} #trim v from tag
+            if [ -z "$LATEST_TAG" ]
+            then
+              LATEST_TAG="latest" && [[ "$CIRCLE_BRANCH" == "develop" ]] && LATEST_TAG="dev"
+            fi
+            #
+            sudo docker build --pull -t $DOCKERHUB_REPO/dojo-tor:$LATEST_TAG-amd64 -f  docker/my-dojo/tor/Dockerfile docker/my-dojo/tor
+            sudo docker login --username=$DOCKERHUB_USER --password=$DOCKERHUB_PASS
+            sudo docker push $DOCKERHUB_REPO/dojo-tor:$LATEST_TAG-amd64
+  publish_docker_linuxarm32_dojo-tor:
+    machine:
+      docker_layer_caching: false
+    steps:
+      - checkout  
+      - run:
+          command: |
+            sudo docker run --rm --privileged multiarch/qemu-user-static:register --reset
+            LATEST_TAG=${CIRCLE_TAG:1} #trim v from tag
+            #
+            LATEST_TAG=${CIRCLE_TAG:1} #trim v from tag
+            if [ -z "$LATEST_TAG" ]
+            then
+              LATEST_TAG="latest" && [[ "$CIRCLE_BRANCH" == "develop" ]] && LATEST_TAG="dev"
+            fi
+            #
+            sudo docker build --pull -t $DOCKERHUB_REPO/dojo-tor:$LATEST_TAG-arm32v7 -f  docker/my-dojo/tor/Dockerfile docker/my-dojo/tor
+            sudo docker login --username=$DOCKERHUB_USER --password=$DOCKERHUB_PASS
+            sudo docker push $DOCKERHUB_REPO/dojo-tor:$LATEST_TAG-arm32v7
+  publish_docker_linuxarm64_dojo-tor:
+    machine:
+      docker_layer_caching: false
+    steps:
+      - checkout
+      - run:
+          command: |
+            sudo docker run --rm --privileged multiarch/qemu-user-static:register --reset
+            LATEST_TAG=${CIRCLE_TAG:1} #trim v from tag
+            #
+            LATEST_TAG=${CIRCLE_TAG:1} #trim v from tag
+            if [ -z "$LATEST_TAG" ]
+            then
+              LATEST_TAG="latest" && [[ "$CIRCLE_BRANCH" == "develop" ]] && LATEST_TAG="dev"
+            fi
+            #
+            sudo docker build --pull -t $DOCKERHUB_REPO/dojo-tor:$LATEST_TAG-arm64v8 -f  docker/my-dojo/tor/Dockerfile docker/my-dojo/tor
+            sudo docker login --username=$DOCKERHUB_USER --password=$DOCKERHUB_PASS
+            sudo docker push $DOCKERHUB_REPO/dojo-tor:$LATEST_TAG-arm64v8
+  publish_docker_multiarch_dojo-tor:
+    machine:
+      enabled: true
+      image: circleci/classic:201808-01
+    steps:
+      - run:
+          command: |
+            # Turn on Experimental features
+            sudo mkdir $HOME/.docker
+            sudo sh -c 'echo "{ \"experimental\": \"enabled\" }" >> $HOME/.docker/config.json'
+            #
+            sudo docker login --username=$DOCKERHUB_USER --password=$DOCKERHUB_PASS
+            #
+            LATEST_TAG=${CIRCLE_TAG:1} #trim v from tag
+            #
+            LATEST_TAG=${CIRCLE_TAG:1} #trim v from tag
+            if [ -z "$LATEST_TAG" ]
+            then
+              LATEST_TAG="latest" && [[ "$CIRCLE_BRANCH" == "develop" ]] && LATEST_TAG="dev"
+            fi
+            #
+            sudo docker manifest create --amend $DOCKERHUB_REPO/dojo-tor:$LATEST_TAG $DOCKERHUB_REPO/dojo-tor:$LATEST_TAG-amd64 $DOCKERHUB_REPO/dojo-tor:$LATEST_TAG-arm32v7 $DOCKERHUB_REPO/dojo-tor:$LATEST_TAG-arm64v8
+            sudo docker manifest annotate $DOCKERHUB_REPO/dojo-tor:$LATEST_TAG $DOCKERHUB_REPO/dojo-tor:$LATEST_TAG-amd64 --os linux --arch amd64
+            sudo docker manifest annotate $DOCKERHUB_REPO/dojo-tor:$LATEST_TAG $DOCKERHUB_REPO/dojo-tor:$LATEST_TAG-arm32v7 --os linux --arch arm --variant v7
+            sudo docker manifest annotate $DOCKERHUB_REPO/dojo-tor:$LATEST_TAG $DOCKERHUB_REPO/dojo-tor:$LATEST_TAG-arm64v8 --os linux --arch arm64 --variant v8
+            sudo docker manifest push $DOCKERHUB_REPO/dojo-tor:$LATEST_TAG -p
+
+
+workflows:
+  version: 2
+
+  publish:
+    jobs:
+      - publish_docker_linuxamd64_dojo-nodejs:
+          filters:
+            branches:
+              only:
+                - master
+                - develop
+            # only act on version tags
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*/
+      - publish_docker_linuxarm32_dojo-nodejs:
+          filters:
+            branches:
+              only:
+                - master
+                - develop
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*/
+      - publish_docker_linuxarm64_dojo-nodejs:
+           filters:
+            branches:
+              only:
+                - master
+                - develop
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*/
+      - publish_docker_multiarch_dojo-nodejs:
+          requires:
+            - publish_docker_linuxamd64_dojo-nodejs
+            - publish_docker_linuxarm32_dojo-nodejs
+            - publish_docker_linuxarm64_dojo-nodejs
+          filters:
+            branches:
+              only:
+                - master
+                - develop
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*/
+      - publish_docker_linuxamd64_dojo-db:
+          filters:
+            branches:
+              only:
+                - master
+                - develop
+            # only act on version tags
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*/
+      - publish_docker_linuxarm32_dojo-db:
+          filters:
+            branches:
+              only:
+                - master
+                - develop
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*/
+      - publish_docker_linuxarm64_dojo-db:
+           filters:
+            branches:
+              only:
+                - master
+                - develop
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*/
+      - publish_docker_multiarch_dojo-db:
+          requires:
+            - publish_docker_linuxamd64_dojo-db
+            - publish_docker_linuxarm32_dojo-db
+            - publish_docker_linuxarm64_dojo-db
+          filters:
+            branches:
+              only:
+                - master
+                - develop
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*/
+      - publish_docker_linuxamd64_dojo-nginx:
+                filters:
+                  branches:
+                    only:
+                      - master
+                      - develop
+                  # only act on version tags
+                  tags:
+                    only: /v[0-9]+(\.[0-9]+)*/
+      - publish_docker_linuxarm32_dojo-nginx:
+          filters:
+            branches:
+              only:
+                - master
+                - develop
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*/
+      - publish_docker_linuxarm64_dojo-nginx:
+           filters:
+            branches:
+              only:
+                - master
+                - develop
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*/
+      - publish_docker_multiarch_dojo-nginx:
+          requires:
+            - publish_docker_linuxamd64_dojo-nginx
+            - publish_docker_linuxarm32_dojo-nginx
+            - publish_docker_linuxarm64_dojo-nginx
+          filters:
+            branches:
+              only:
+                - master
+                - develop
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*/
+      - publish_docker_linuxamd64_dojo-tor:
+          filters:
+
+            branches:
+              only:
+                - master
+                - develop
+            # only act on version tags
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*/
+      - publish_docker_linuxarm32_dojo-tor:
+          filters:
+            branches:
+              only:
+                - master
+                - develop
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*/
+      - publish_docker_linuxarm64_dojo-tor:
+           filters:
+            branches:
+              only:
+                - master
+                - develop
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*/
+      - publish_docker_multiarch_dojo-tor:
+          requires:
+            - publish_docker_linuxamd64_dojo-tor
+            - publish_docker_linuxarm32_dojo-tor
+            - publish_docker_linuxarm64_dojo-tor
+          filters:
+            branches:
+              only:
+                - master
+                - develop
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*/

--- a/docker/my-dojo/nginx/Dockerfile
+++ b/docker/my-dojo/nginx/Dockerfile
@@ -8,9 +8,8 @@ RUN       mkdir -p "$LOGS_DIR" && \
 
 # Copy configuration files
 COPY      ./nginx.conf /etc/nginx/nginx.conf
-COPY      ./dojo.conf /etc/nginx/sites-enabled/dojo.conf
-COPY      ./dojo-explorer.conf /etc/nginx/sites-enabled/dojo-explorer.conf
-
+COPY      foo ./dojo-explorer.con[f] ./dojo.con[f] /etc/nginx/sites-enabled/
+RUN       rm /etc/nginx/sites-enabled/foo
 # Copy wait-for script
 COPY      ./wait-for /wait-for
 


### PR DESCRIPTION
This PR adds CircleCI integration so that you auto build and publish all your docker containers to Docker Hub. 
To get set up you need to:
* Create account with Docker hub
* Create account with Circle CI
* Enable project in CircleCI
* Configure project in Circle CI with the following environment variables:
  * DOCKERHUB_REPO - the docker hub repo, usually your username (e.g **kukks**/btcpayserver)
  * DOCKERHUB_USER - the user to login with 
  * DOCKERHUB_PASS - password to login with

When will this build?
* On new commits to `develop`, images are built with a `-dev` suffix
* On new commits to `master`, images are built with a `-latest` suffix
* On new tags with the format `vx.x..n`, images are built with a `-x.x..n` suffix (e.g v0.0.1.1.1 = `0.0.1.1.1`,  v0.0.1.1-rc1 = `0.0.1.1-rc1`)

What images are built?
AMD64, ARM32 and ARM64 images, for nodejs, db, nginx and tor. I had to modify the nginx dockerfile so that the dojo conf files would be optional at build time (I recommend you switch to volume mapping the file in place to not require to build the image each time the config changes anyway). The `foo` file is only there to trigger optional copying of the conf if they are found (based on [this](https://stackoverflow.com/a/46801962/275504)) and is removed immediately after.

