### PR TITLE
add controls and confirmations before reinstalls and uninstalls

### DIFF
--- a/docker/my-dojo/conf/docker-mysql.conf.tpl
+++ b/docker/my-dojo/conf/docker-mysql.conf.tpl
@@ -3,13 +3,16 @@
 #########################################
 
 # Password of MySql root account
+# Warning: This option must not be modified after the first installation
 # Type: alphanumeric
 MYSQL_ROOT_PASSWORD=rootpassword
 
 # User account used for db access
+# Warning: This option must not be modified after the first installation
 # Type: alphanumeric
 MYSQL_USER=samourai
 
 # Password of of user account
+# Warning: This option must not be modified after the first installation
 # Type: alphanumeric
 MYSQL_PASSWORD=password

--- a/docker/my-dojo/install/install-scripts.sh
+++ b/docker/my-dojo/install/install-scripts.sh
@@ -31,6 +31,18 @@ get_confirmation() {
   done
 }
 
+# Confirm reinstallation
+get_confirmation_reinstall() {
+  while true; do
+    read -p "Do you really wish to reinstall Dojo on your computer? [y/n]" yn
+    case $yn in
+      [Yy]* ) return 0;;
+      [Nn]* ) echo "Reinstallation was cancelled."; return 1;;
+      * ) echo "Please answer yes or no.";;
+    esac
+  done
+}
+
 # Initialize configuration files from templates
 init_config_files() {
   # Initialize db scripts

--- a/docker/my-dojo/install/uninstall-scripts.sh
+++ b/docker/my-dojo/install/uninstall-scripts.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Confirm uninstallation
+get_confirmation() {
+  while true; do
+    echo "This operation is going to uninstall Dojo from your computer."
+    echo "Warning: This will delete from disk all the data stored by your Dojo (blockchain data, Dojo db, etc)."
+    read -p "Do you wish to continue? [y/n]" yn
+    case $yn in
+      [Yy]* ) return 0;;
+      [Nn]* ) echo "Uninstallation was cancelled."; return 1;;
+      * ) echo "Please answer yes or no.";;
+    esac
+  done
+}


### PR DESCRIPTION
add the following controls and confirmation requests:

- ask for confirmation before uninstalling dojo
- check if dojo was already installed on the machine before running a new install
- ask for confirmation before reinstalling dojo
- force uninstall before reinstalling dojo on the machine

**rationale**

it shall prevent mismatches between db credentials stored in docker-mysql.conf and in the database initialized by a previous install. 