### PR TITLE
Drop unneeded reverseBuffer util method

### DIFF
--- a/lib/remote-importer/local-indexer-wrapper.js
+++ b/lib/remote-importer/local-indexer-wrapper.js
@@ -6,7 +6,6 @@
 
 const bitcoin = require('bitcoinjs-lib')
 const Logger = require('../logger')
-const util = require('../util')
 const network = require('../bitcoin/network')
 const activeNet = network.network
 const keys = require('../../keys')[network.key]
@@ -40,7 +39,7 @@ class LocalIndexerWrapper extends Wrapper {
   _getScriptHash(address) {
     const bScriptPubKey = bitcoin.address.toOutputScript(address, activeNet)
     const bScriptHash = bitcoin.crypto.sha256(bScriptPubKey)
-    return util.reverseBuffer(bScriptHash).toString('hex')
+    return bScriptHash.reverse().toString('hex')
   }
 
   /**

--- a/lib/util.js
+++ b/lib/util.js
@@ -128,26 +128,6 @@ class Util {
 
 
   /**
-   * Reverse buffer content (swap endiannes)
-   */
-  static reverseBuffer(buffer) {
-    if (buffer.length < 1)
-      return buffer
-
-    let j = buffer.length - 1
-    let tmp = 0
-
-    for (let i = 0; i < buffer.length / 2; i++) {
-      tmp = buffer[i]
-      buffer[i] = buffer[j]
-      buffer[j] = tmp
-      j--
-    }
-
-    return buffer
-  }
-
-  /**
    * Sum an array of values
    */
   static sum(arr) {


### PR DESCRIPTION
In Node.js a `Buffer` is also a subclass of `TypedArray` so there's no need for a `reverseBuffer` util method, you can just use `TypedArray.prototype.reverse()` directly on a `Buffer` instance.

```
$ node
Welcome to Node.js v12.11.1.
Type ".help" for more information.
> buf = Buffer.from('Test')
<Buffer 54 65 73 74>
> buf.reverse()
<Buffer 74 73 65 54>
```

I haven't tested the PR because attempting to run tests or require `local-index-wrapper.js` just gives me `Error: Cannot find module '../../keys/'`.

I'm not really familiar with Dojo, I was just looking at how the importer wrappers were implemented and saw this.