### PR TITLE
add dynamic switch of startup mode

### DIFF
--- a/tracker/blockchain-processor.js
+++ b/tracker/blockchain-processor.js
@@ -55,9 +55,12 @@ class BlockchainProcessor extends AbstractProcessor {
    * @returns {Promise}
    */
   async catchup() {
-    // Consider that we are in IBD mode if Dojo is far in the past
     const highest = await db.getHighestBlock()
-    this.isIBD = highest.blockHeight < 570000
+    const info = await this.client.getblockchaininfo()
+    const daemonNbHeaders = info.headers
+
+    // Consider that we are in IBD mode if Dojo is far in the past (> 13,000 blocks)
+    this.isIBD = highest.blockHeight < daemonNbHeaders - 13000
 
     if (this.isIBD)
       return this.catchupIBDMode()


### PR DESCRIPTION
implement a dynamic computation of the threshold defining the startup mode of the tracker (ibd or normal).

ibd mode is used if a large lag is detected between the tracker and the tip (more than 13k blocks).

it implies that a manual rescan will be needed if dojo is stopped for more than 3 months.