### PR TITLE
Fix typo in install scripts causing a copy error when installing or upgrading

### DIFF
--- a/docker/my-dojo/install/install-scripts.sh
+++ b/docker/my-dojo/install/install-scripts.sh
@@ -95,7 +95,7 @@ init_config_files() {
   if [ "$WHIRLPOOL_INSTALL" == "on" ]; then
     cp ./nginx/whirlpool.conf ./nginx/dojo-whirlpool.conf
   else
-    cp /dev/null ./nginx/dojo-ewhirlpool.conf
+    cp /dev/null ./nginx/dojo-whirlpool.conf
   fi
   echo "Initialized dojo-whirlpool.conf (nginx)"
 

--- a/docker/my-dojo/install/upgrade-scripts.sh
+++ b/docker/my-dojo/install/upgrade-scripts.sh
@@ -80,7 +80,7 @@ update_config_files() {
   if [ "$WHIRLPOOL_INSTALL" == "on" ]; then
     cp ./nginx/whirlpool.conf ./nginx/dojo-whirlpool.conf
   else
-    cp /dev/null ./nginx/dojo-ewhirlpool.conf
+    cp /dev/null ./nginx/dojo-whirlpool.conf
   fi
   echo "Initialized dojo-whirlpool.conf (nginx)"
 


### PR DESCRIPTION
Fix a typo in install scripts causing the following error when installing or upgrading:

```
Step 7/9 : COPY      ./dojo-whirlpool.conf /etc/nginx/sites-enabled/dojo-whirlpool.conf
ERROR: Service 'nginx' failed to build: COPY failed: stat /var/lib/docker/tmp/docker-builder582642515/dojo-whirlpool.conf: no such file or directory
```