### PR TITLE
Tests/add unit tests

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.js]
+max_line_length = 160
+indent_size = 4
+indent_style = space

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,121 @@
+{
+  "env": {
+    "node": true,
+    "es2021": true,
+    "mocha": true
+  },
+  "plugins": [
+    "import",
+    "unicorn"
+  ],
+  "extends": [
+    "eslint:recommended",
+    "plugin:import/recommended",
+    "plugin:unicorn/recommended"
+  ],
+  "ignorePatterns": ["*.min.js"],
+  "parserOptions": {
+    "ecmaVersion": 13,
+    "sourceType": "module"
+  },
+  "rules": {
+    "array-callback-return": [
+      "error",
+      {
+        "checkForEach": true
+      }
+    ],
+    "complexity": "error",
+    "no-constructor-return": "error",
+    "no-self-compare": "error",
+    "no-template-curly-in-string": "warn",
+    "no-unmodified-loop-condition": "warn",
+    "no-unreachable-loop": "error",
+    "require-atomic-updates": "error",
+    "indent": [
+      "error",
+      4
+    ],
+    "linebreak-style": [
+      "error",
+      "unix"
+    ],
+    "quotes": [
+      "error",
+      "single"
+    ],
+    "semi": [
+      "error",
+      "never"
+    ],
+    "max-len": [
+      "warn",
+      160
+    ],
+    "eol-last": "error",
+    "eqeqeq": [
+      "error",
+      "smart"
+    ],
+    "radix": "error",
+    "dot-notation": "warn",
+    "no-array-constructor": "error",
+    "no-extend-native": "error",
+    "no-extra-bind": "error",
+    "no-implicit-coercion": "error",
+    "no-invalid-this": "error",
+    "no-iterator": "error",
+    "no-lonely-if": "error",
+    "no-loop-func": "error",
+    "no-multi-assign": "error",
+    "no-negated-condition": "error",
+    "no-undef-init": "error",
+    "no-useless-call": "error",
+    "no-useless-constructor": "error",
+    "no-useless-return": "error",
+    "prefer-arrow-callback": "warn",
+    "prefer-template": "warn",
+
+    "import/no-self-import": "error",
+    "import/no-cycle": "error",
+    "import/no-useless-path-segments": "error",
+    "import/no-deprecated": "warn",
+    "import/no-extraneous-dependencies": "error",
+    "import/no-mutable-exports": "error",
+    "import/first": "error",
+    "import/no-duplicates": "error",
+    "import/newline-after-import": "error",
+    "import/extensions": [
+      "error",
+      "ignorePackages"
+    ],
+
+    "unicorn/no-null": "off",
+    "unicorn/no-process-exit": "off",
+    "unicorn/prefer-node-protocol": "off",
+    "unicorn/prevent-abbreviations": "off",
+    "unicorn/no-array-for-each": "warn",
+    "unicorn/numeric-separators-style": "off",
+    "unicorn/require-post-message-target-origin": "off",
+    "unicorn/no-array-reduce": "off",
+    "unicorn/prefer-dom-node-dataset": "off",
+    "unicorn/switch-case-braces": "off"
+  },
+  "overrides": [{
+    "env": {
+      "browser": true
+    },
+    "files": ["./static/**/*.js"],
+    "globals": {
+      "QRCode": "readonly",
+      "conf": "readonly",
+      "screenScripts": "readonly",
+      "lib_msg": "readonly",
+      "lib_auth": "readonly",
+      "lib_cmn": "readonly",
+      "lib_api": "readonly",
+      "lib_fmt": "readonly",
+      "lib_errors": "readonly"
+    }
+  }]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,14 @@
 db-scripts/updates/
 db-scripts/1_db.sql
 db-scripts/2_update.sql
-docker/my-dojo/conf/docker-bitcoind.conf
-docker/my-dojo/conf/docker-mysql.conf
-docker/my-dojo/conf/docker-node.conf
+docker/my-dojo/conf/*.conf
+docker/my-dojo/conf/*.conf.save
 keys/index.js
 keys/sslcert/
 node_modules/
 private-tests/
 static/admin/conf/index.js
+static/admin-legacy
+static/admin-legacy/
 *.log
+/pm2.config.cjs

--- a/accounts/api-helper.js
+++ b/accounts/api-helper.js
@@ -79,7 +79,7 @@ class ApiHelper {
   /**
    * Check entities passed as url params
    * @param {object} params - request query or body object
-   * @returns {boolean} return true if conditions are met, false otherwise
+   * @returns {boolean} return true if there is at least one not empty entity parameter, false otherwise
    */
   checkEntitiesParams(params) {
     return params.active

--- a/accounts/api-helper.js
+++ b/accounts/api-helper.js
@@ -145,8 +145,11 @@ class ApiHelper {
   /**
    * Validate a request argument
    * @param {string} arg - request argument
+   * @returns {boolean} return true if all params have just alphanumeric characteres
    */
   subValidateEntitiesParams(arg) {
+        if (typeof arg !== 'string')
+            return false
     for (let item of arg.split('|')) {
       const isValid = validator.isAlphanumeric(item)
       if (!isValid)

--- a/test/unit-tests/api-helper.spec.js
+++ b/test/unit-tests/api-helper.spec.js
@@ -2,28 +2,48 @@ const assert = require("assert");
 const apiHelper = require("../../accounts/api-helper");
 
 describe("APIHelper", function () {
-  describe("checkEntitiesParams()", function () {
-    it("Given there is at least one not empty entity parameter Should return true", function () {
-        const validParams = {
-            active: true,
-        };
-        assert(apiHelper.checkEntitiesParams(validParams));
+    describe("checkEntitiesParams()", function () {
+        it("Given there is at least one not empty entity parameter Should return true", function () {
+            const validParams = {
+                active: true,
+            };
+            assert(apiHelper.checkEntitiesParams(validParams));
+        });
+
+        it("Given no empty entity parameter Should return true", function () {
+            const validParams = {
+                active: true,
+                new: true,
+                pubkey: "exampleValue",
+                bip49: "exampleValue",
+                bip84: "exampleValue",
+            };
+            assert(apiHelper.checkEntitiesParams(validParams));
+            });
+
+        it("Given all empty entity parameter Should return false", function () {
+            const invalidParams = {};
+            assert(!apiHelper.checkEntitiesParams(invalidParams));
+        });
     });
 
-    it("Given no empty entity parameter Should return true", function () {
-        const validParams = {
-            active: true,
-            new: true,
-            pubkey: "exampleValue",
-            bip49: "exampleValue",
-            bip84: "exampleValue",
-        };
-        assert(apiHelper.checkEntitiesParams(validParams));
-      });
+    describe("subValidateEntitiesParams()", function () {
+        it("Given all params has just alphanumeric text Should return true", function () {
+            const params = "item1|item2|item3"
+            assert(apiHelper.subValidateEntitiesParams(params))
+        })
 
-    it("Given all empty entity parameter Should return false", function () {
-        const invalidParams = {};
-        assert(!apiHelper.checkEntitiesParams(invalidParams));
-    });
-  });
+        it("Given invalid params type Should return false", function () {
+            const params = false
+            assert(!apiHelper.subValidateEntitiesParams(params))
+        })
+
+        it("Given empty text or item Should return false", function () {
+            const emptyTextParams = ""
+            assert(!apiHelper.subValidateEntitiesParams(emptyTextParams))
+
+            const emptyItemParams = "| "
+            assert(!apiHelper.subValidateEntitiesParams(emptyItemParams))
+        })
+    })
 });

--- a/test/unit-tests/api-helper.spec.js
+++ b/test/unit-tests/api-helper.spec.js
@@ -1,0 +1,29 @@
+const assert = require("assert");
+const apiHelper = require("../../accounts/api-helper");
+
+describe("APIHelper", function () {
+  describe("checkEntitiesParams()", function () {
+    it("Given there is at least one not empty entity parameter Should return true", function () {
+        const validParams = {
+            active: true,
+        };
+        assert(apiHelper.checkEntitiesParams(validParams));
+    });
+
+    it("Given no empty entity parameter Should return true", function () {
+        const validParams = {
+            active: true,
+            new: true,
+            pubkey: "exampleValue",
+            bip49: "exampleValue",
+            bip84: "exampleValue",
+        };
+        assert(apiHelper.checkEntitiesParams(validParams));
+      });
+
+    it("Given all empty entity parameter Should return false", function () {
+        const invalidParams = {};
+        assert(!apiHelper.checkEntitiesParams(invalidParams));
+    });
+  });
+});


### PR DESCRIPTION
- add unit test to checkEntitiesParams() and subValidateEntitiesParams() methods
- validate params type before use it as string to avoid errors
- bring .editorconfig, .gitignore, and .eslintrc.json from Gitlab repository

@pajasevi 